### PR TITLE
Fix: Compact currency format for large numbers

### DIFF
--- a/src/components/expenses/ExpenseCategoryCharts.tsx
+++ b/src/components/expenses/ExpenseCategoryCharts.tsx
@@ -114,7 +114,7 @@ const ExpenseCategoryCharts = ({
                   <div className="space-y-1">
                     <div className="flex items-baseline justify-between">
                       <span className="text-xl font-bold">
-                        {formatCurrency(category.amount)}
+                        {formatCurrency(category.amount, {compact: true})}
                       </span>
                       <span className="text-muted-foreground text-xs">
                         {category.count}{" "}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,8 +44,39 @@ export const getCategoryColor = (categoryName: string): string => {
 
 export const formatCurrency = (
   amount: number,
-  options?: Intl.NumberFormatOptions,
+  options?: Intl.NumberFormatOptions & {compact?: boolean}
 ) => {
+
+    // Short hand formating(Fix big number out of the box issue)
+    if(options?.compact){
+      const absAmount = Math.abs(amount);
+      let formatted = amount.toString();
+      let suffix = "";
+
+      if(absAmount >= 1_000_000_000){
+        formatted = (absAmount / 1_000_000_000).toFixed(1).replace(/\.0$/, "")
+        suffix = "B"
+      }else if(absAmount >= 1_000_000){
+        formatted = (absAmount / 1_000_000).toFixed(1).replace(/\.0$/, "")
+        suffix = "M"
+      }else if(absAmount >= 10_000){
+        formatted = (absAmount / 1000).toFixed(1).replace(/\.0$/, "")
+        suffix = "K"
+      }
+
+
+      // Return with currency symbol
+    const formattedCurrency =  new Intl.NumberFormat(LOCALE_CONFIG.locale, {
+      currency: LOCALE_CONFIG.currency,
+      maximumFractionDigits: 1,
+      style: "currency",
+    }).format(parseFloat(formatted))
+
+    return `${formattedCurrency}${suffix}`
+    }
+
+
+    // Default formatting(non compact)
   return new Intl.NumberFormat(LOCALE_CONFIG.locale, {
     currency: LOCALE_CONFIG.currency,
     style: LOCALE_CONFIG.style,


### PR DESCRIPTION
This PR introduces compact currency formatting to improve readability of large monetary values in the category cards and total displays.
Previously, values like 1000000 overflowed their containers or appeared hard to read.

**Changes made**

- Added compact formatting logic in formatcurrency utility:
- Supports shorthand notation:

  - 10,000 -> 10K
  - 1,000,000 -> 1M
  - 1,000,000,000 -> 1B